### PR TITLE
Removed '--v2' option from ionic (Ionic v3.4.0 now fails to execute)

### DIFF
--- a/generator-fireloop/generators/ionic/index.js
+++ b/generator-fireloop/generators/ionic/index.js
@@ -27,7 +27,7 @@ module.exports = generators.Base.extend({
             }
             else {
                 this.log(chalk.green("\n\nCreating new Ionic 2 Application: " + answers.name));
-                this.spawnCommand('ionic', ['start', answers.name, '--v2'], { shell: true })
+                this.spawnCommand('ionic', ['start', answers.name], { shell: true })
                     .on('exit', function (code) {
                     if (code === 0) {
                         _this.options.current = answers.name;


### PR DESCRIPTION
#### What type of pull request are you creating?
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?

Write a reason if none (e.g just fixed a typo):
None.  Tested with Ionic 3.4.0

#### Please add a description for your pull request:
Removed '--v2' option from Ionic CLI spawn.
Latest ionic v3.4.0 fails to execute with '--2' command line option.